### PR TITLE
Change far launch position

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/AprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/AprilTag.java
@@ -173,7 +173,7 @@ public class AprilTag {
 
             if (allianceColor == AllianceColor.RED_ALLIANCE) {
                 //rangeError = -(targetTag.ftcPose.range - finalDesiredDistance);
-                headingError = (targetTag.ftcPose.bearing + finalDesiredHeading);
+                headingError = (targetTag.ftcPose.bearing - 3);
                 yawError = -(targetTag.ftcPose.yaw + finalDesiredYaw);
             }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/AprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/AprilTag.java
@@ -33,9 +33,10 @@ public class AprilTag {
 
 
     //Changes in the (physical) chassis change these values due to small differences in how the wheels move, so ajustment will be needed before competitions
-    final double FAR_DESIRED_DISTANCE = 120; // this is how close the camera should get to the target (inches)
-    final double FAR_DESIRED_HEADING = -6; // Defaults are for Blue alliance
-    final double FAR_DESIRED_YAW = 25;
+    final double FAR_DESIRED_DISTANCE = 125; // this is how close the camera should get to the target (inches)
+    final double FAR_DESIRED_HEADING = -2; // Defaults are for Blue alliance
+    final double FAR_DESIRED_YAW = 32;
+
     final double CLOSE_DISTANCE = 6;
 
     final double PARK_DESIRED_DISTANCE = 127.6;
@@ -173,7 +174,7 @@ public class AprilTag {
 
             if (allianceColor == AllianceColor.RED_ALLIANCE) {
                 //rangeError = -(targetTag.ftcPose.range - finalDesiredDistance);
-                headingError = (targetTag.ftcPose.bearing - 3);
+                headingError = (targetTag.ftcPose.bearing + finalDesiredHeading);
                 yawError = -(targetTag.ftcPose.yaw + finalDesiredYaw);
             }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/AprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/AprilTag.java
@@ -33,9 +33,9 @@ public class AprilTag {
 
 
     //Changes in the (physical) chassis change these values due to small differences in how the wheels move, so ajustment will be needed before competitions
-    final double FAR_DESIRED_DISTANCE = 127.6; // this is how close the camera should get to the target (inches)
-    final double FAR_DESIRED_HEADING = -5; // Defaults are for Blue alliance
-    final double FAR_DESIRED_YAW = 17.5;
+    final double FAR_DESIRED_DISTANCE = 120; // this is how close the camera should get to the target (inches)
+    final double FAR_DESIRED_HEADING = -6; // Defaults are for Blue alliance
+    final double FAR_DESIRED_YAW = 25;
     final double CLOSE_DISTANCE = 6;
 
     final double PARK_DESIRED_DISTANCE = 127.6;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/LauncherImpl.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/LauncherImpl.java
@@ -16,10 +16,10 @@ public class LauncherImpl implements Runnable, Launcher {
     private static final double SPEED_3FT = 1;
     private static final double manualIncrementQuotient = 165; //Divides
     private static final double FAR_LAUNCHER_SPEED = 0.7000;
-    private static final double FAR_HOOD_ANGLE =  0.1000;
+    private static final double FAR_HOOD_ANGLE =  0.1075;
 
     private static final double CLOSE_LAUNCHER_SPEED = 0.6;
-    private static final double CLOSE_HOOD_ANGLE =  0.0850;
+    private static final double CLOSE_HOOD_ANGLE =  0.0950;
     public static final double MINIMUM_HOOD_ANGLE = 0.0790;
     public static final double MAXIMUM_HOOD_ANGLE = 0.1157;
     private final Telemetry telemetry;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/LauncherImpl.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/LauncherImpl.java
@@ -18,8 +18,8 @@ public class LauncherImpl implements Runnable, Launcher {
     private static final double FAR_LAUNCHER_SPEED = 0.7000;
     private static final double FAR_HOOD_ANGLE =  0.1075;
 
-    private static final double CLOSE_LAUNCHER_SPEED = 0.6;
-    private static final double CLOSE_HOOD_ANGLE =  0.0950;
+    private static final double CLOSE_LAUNCHER_SPEED = 0.45;
+    private static final double CLOSE_HOOD_ANGLE =  0.0850;
     public static final double MINIMUM_HOOD_ANGLE = 0.0790;
     public static final double MAXIMUM_HOOD_ANGLE = 0.1157;
     private final Telemetry telemetry;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/TransferSystemImpl.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/TransferSystemImpl.java
@@ -12,7 +12,7 @@ public class TransferSystemImpl implements TransferSystem {
     private Servo transferGate;
     private GateStates gateState;
     private ElapsedTime timeElapsed = new ElapsedTime(ElapsedTime.Resolution.MILLISECONDS);
-    private final double TIME_TO_CLOSE = 175;
+    private final double TIME_TO_CLOSE = 100;
     public AutoGateState autoGateOpen = AutoGateState.TELEOP_GATE;
 
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/TransferSystemImpl.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/mechanisms/TransferSystemImpl.java
@@ -15,6 +15,8 @@ public class TransferSystemImpl implements TransferSystem {
     private final double TIME_TO_CLOSE = 100;
     public AutoGateState autoGateOpen = AutoGateState.TELEOP_GATE;
 
+    public boolean lastState2A = false;
+
 
     public TransferSystemImpl(LinearOpMode OpMode) {
         this.opMode = OpMode;
@@ -30,7 +32,7 @@ public class TransferSystemImpl implements TransferSystem {
 
         transferGate.setDirection(Servo.Direction.FORWARD);
 
-        if(opMode.gamepad2.a || autoGateOpen == AutoGateState.AUTO_GATE_OPEN){
+        if((opMode.gamepad2.a && !lastState2A) || autoGateOpen == AutoGateState.AUTO_GATE_OPEN){
             this.open();
         }
         else if ((timeElapsed.time() >= TIME_TO_CLOSE) || autoGateOpen == AutoGateState.AUTO_GATE_CLOSE){

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/production/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/production/Robot.java
@@ -141,7 +141,7 @@ public class Robot implements Runnable{
         runChassis = true;
 
         aprilTag.autoAprilTagDetect = true;
-        autoSleep(10000);
+        autoSleep(5000);
         aprilTag.autoAprilTagDetect = false;
 
         autoResetMotor(500);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/production/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/production/Robot.java
@@ -159,12 +159,12 @@ public class Robot implements Runnable{
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_OPEN;
         autoSleep(250);
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_CLOSE;
-        autoSleep(1000);
+        autoSleep(2000);
 
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_OPEN;
         autoSleep(250);
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_CLOSE;
-        autoSleep(1000);
+        autoSleep(2000);
 
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_OPEN;
         autoSleep(250);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/production/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/production/Robot.java
@@ -101,6 +101,16 @@ public class Robot implements Runnable{
         }
     }
 
+    public void autoResetMotor(long timeMS){
+        chassis.moveRobot(0,0,0);
+        try {
+            Thread.sleep(timeMS);
+        } catch (InterruptedException e) {
+            //throw new RuntimeException(e);
+        }
+
+    }
+
     double strafeMultiplier = 1;
     double turnMultiplier = 1;
 
@@ -121,23 +131,6 @@ public class Robot implements Runnable{
         //Defaults to blue alliance values
 
         //TODO Tune these values
-        
-        // Move forward to see april tag
-
-        runChassis = false;
-
-        this.chassis.moveRobot(-0.5, 0,0);
-        autoSleep(1500);
-        this.chassis.moveRobot(0, 0,0);
-        autoSleep(500);
-
-        //Turn to see april tag
-
-        this.chassis.moveRobot(0,0,1 * turnMultiplier);
-        autoSleep(100);
-
-        this.chassis.moveRobot(0, 0,0);
-        autoSleep(500);
 
         // Start Launcher
 
@@ -151,8 +144,7 @@ public class Robot implements Runnable{
         autoSleep(10000);
         aprilTag.autoAprilTagDetect = false;
 
-        this.chassis.moveRobot(0, 0,0);
-        autoSleep(500);
+        autoResetMotor(500);
 
         //launch
 
@@ -176,6 +168,14 @@ public class Robot implements Runnable{
         ((LauncherImpl)launcher).autoFarLaunch = false;
 
         // Possibly move back to start and/or out of the way
+
+        runChassis = false;
+
+        this.chassis.moveRobot(1,0,0);
+        autoSleep(500);
+        autoResetMotor(500);
+
+        runChassis = true;
     }
 
     public void autoCloseLaunch() {
@@ -187,9 +187,8 @@ public class Robot implements Runnable{
         
         //Slightly move away from the goal
         this.chassis.moveRobot(0.5, 0,0);
-        autoSleep(200);
-        this.chassis.moveRobot(0, 0,0);
-        autoSleep(500);
+        autoSleep(160);
+        autoResetMotor(500);
 
         // Start Launcher
         ((LauncherImpl)launcher).autoCloseLaunch = true;
@@ -213,6 +212,23 @@ public class Robot implements Runnable{
         autoSleep(1000);
 
         ((LauncherImpl)launcher).autoCloseLaunch = false;
+
+
+
+        runChassis = false;
+
+        autoResetMotor(500);
+
+        this.chassis.moveRobot(-1, 0,0);
+        autoSleep(500);
+        autoResetMotor(500);
+
+        this.chassis.moveRobot(0, -1 * strafeMultiplier,0);
+        autoSleep(500);
+
+        autoResetMotor(500);
+
+        runChassis = true;
 
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/production/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/production/Robot.java
@@ -200,12 +200,12 @@ public class Robot implements Runnable{
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_OPEN;
         autoSleep(250);
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_CLOSE;
-        autoSleep(1000);
+        autoSleep(2000);
 
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_OPEN;
         autoSleep(250);
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_CLOSE;
-        autoSleep(1000);
+        autoSleep(2000);
 
         ((TransferSystemImpl)transferSystem).autoGateOpen = AutoGateState.AUTO_GATE_OPEN;
         autoSleep(250);
@@ -218,6 +218,10 @@ public class Robot implements Runnable{
 
     @Override
     public void run() {
-        start();
+        try{
+            start();
+        }catch (Exception e){
+
+        }
     }
 }


### PR DESCRIPTION
- Changed time scanning april tag from 10s > 5s
- Looked for an issue where the robot wasn't moving out of parking zone after far auto launch, but couldn't find the issue so that might need testing tomorrow morning.
- Consolidated the motor resets into one method for auto
- Changed movement for auto methods (far launch needs to be adjusted)
- Made it so that the button A doesn't keep the gate open when you hold it down.
- Changed auto values to be correct as of 1/8/26
- Fixed red scoring position
- Shortened gate closing time
- Changed far launch position